### PR TITLE
Reconfigure to allow user email display

### DIFF
--- a/app/controllers/trips/checklist_items_controller.rb
+++ b/app/controllers/trips/checklist_items_controller.rb
@@ -1,6 +1,6 @@
 class Trips::ChecklistItemsController < ApplicationController
   def create
-    ChecklistItemFacade.new_item(params[:dashboard_id], params[:checklist_id], params[:name], current_user.id.to_i)
+    ChecklistItemFacade.new_item(params[:dashboard_id], params[:checklist_id], params[:name], current_user.id, current_user.email)
     redirect_to "/trips/dashboard/#{params[:dashboard_id]}/checklist/#{params[:checklist_id]}"
   end
   

--- a/app/facades/checklist_item_facade.rb
+++ b/app/facades/checklist_item_facade.rb
@@ -1,7 +1,7 @@
 class ChecklistItemFacade
   class << self
-    def new_item(trip_id, checklist_id, item_name, user_id)
-      ChecklistItemService.new_item(trip_id, checklist_id, item_name, user_id)
+    def new_item(trip_id, checklist_id, item_name, user_id, user_email)
+      ChecklistItemService.new_item(trip_id, checklist_id, item_name, user_id, user_email)
     end
     
     def edit_item(trip_id, checklist_id, item_id, item_name)

--- a/app/poros/checklist_item.rb
+++ b/app/poros/checklist_item.rb
@@ -1,9 +1,11 @@
 class ChecklistItem
   attr_reader :id,
-              :name
+              :name,
+              :user_email
 
   def initialize(data)
     @id         = data[:id]
     @name       = data[:name]
+    @user_email = data[:user_email]
   end
 end

--- a/app/services/checklist_item_service.rb
+++ b/app/services/checklist_item_service.rb
@@ -1,11 +1,12 @@
 class ChecklistItemService
   class << self
-    def new_item(trip_id, checklist_id, item_name, user_id)
+    def new_item(trip_id, checklist_id, item_name, user_id, user_email)
       response = conn.post(
          "/api/v1/trips/#{trip_id}/checklists/#{checklist_id}/checklist_items"
       ) do |req|
         req.params['name'] = item_name
         req.params['user_id'] = user_id
+        req.params['user_email'] = user_email
       end
     end
     

--- a/app/services/checklist_service.rb
+++ b/app/services/checklist_service.rb
@@ -15,7 +15,7 @@ class ChecklistService
     def single_checklist(trip_id, checklist_id)
       response = conn.get("/api/v1/trips/#{trip_id}/checklists/#{checklist_id}")
 
-      JSON.parse(response.body, symbolize_names: true)
+      parsed = JSON.parse(response.body, symbolize_names: true)
     end
   end
 

--- a/app/views/trips/checklist/show.html.erb
+++ b/app/views/trips/checklist/show.html.erb
@@ -14,7 +14,7 @@
       <li>
         <%= form_with url: "/trips/dashboard/#{@trip_id}/checklist/#{@checklist_id}/checklist_items/#{item.id}", method: :patch, local: true do |f| %>
           <%= f.text_field :name, value: "#{item.name}" %>
-          <%= f.submit "Edit Name" %>
+          <%= f.submit "Edit Name" %> Assigned To: <%= item.user_email %>
         <% end %>
         <%= form_with url: "/trips/dashboard/#{@trip_id}/checklist/#{@checklist_id}/checklist_items/#{item.id}", method: :delete, local: true do |f| %>
           <%= f.submit "Delete Item" %>

--- a/spec/features/checklists/show_spec.rb
+++ b/spec/features/checklists/show_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe "Checklist show page" do
     it 'displays fields with current item names on checklist' do
       expect(page).to have_field(:name, with: 'Cheez-its')
     end
+
+    it 'displays user email next to item' do
+      expect(page).to have_content("mattdkragen@gmail.com")
+    end
   end
 
   describe 'features' do
@@ -83,8 +87,7 @@ RSpec.describe "Checklist show page" do
       user = UserFacade.current_user_info(3112)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-
-      stub_request(:post, "https://travel-buddy-api.herokuapp.com/api/v1/trips/8/checklists/2/checklist_items?name=New%20Item&user_id=3112").
+      stub_request(:post, "https://travel-buddy-api.herokuapp.com/api/v1/trips/8/checklists/2/checklist_items?name=New%20Item&user_email=amee@haag-homenick.net&user_id=3112").
          to_return(status: 200)
 
       stub_request(:get, "https://travel-buddy-api.herokuapp.com/api/v1/trips/#{@trip_id}/checklists/#{@checklist_id}").

--- a/spec/fixtures/checklist_show.json
+++ b/spec/fixtures/checklist_show.json
@@ -5,7 +5,7 @@
         "attributes": {
             "category": "Snacks",
             "trip_id": 8,
-            "item_count": 3,
+            "item_count": 1,
             "items": [
                 {
                     "id": 1,
@@ -13,7 +13,8 @@
                     "user_id": 4,
                     "name": "Cheez-its",
                     "created_at": "2021-09-21T22:55:38.233Z",
-                    "updated_at": "2021-09-21T22:55:38.233Z"
+                    "updated_at": "2021-09-22T23:51:26.107Z",
+                    "user_email": "mattdkragen@gmail.com"
                 }
             ]
         }

--- a/spec/fixtures/new_checklist_item.json
+++ b/spec/fixtures/new_checklist_item.json
@@ -13,7 +13,8 @@
           "user_id": 4,
           "name": "New Item",
           "created_at": "2021-09-21T22:55:38.233Z",
-          "updated_at": "2021-09-21T22:55:38.233Z"
+          "updated_at": "2021-09-21T22:55:38.233Z",
+          "user_email": "mattdkragen@gmail.com"
         }
       ]
     }

--- a/spec/fixtures/updated_checklist_show.json
+++ b/spec/fixtures/updated_checklist_show.json
@@ -13,7 +13,8 @@
           "user_id": 4,
           "name": "Cheese Doodles",
           "created_at": "2021-09-21T22:55:38.233Z",
-          "updated_at": "2021-09-21T22:55:38.233Z"
+          "updated_at": "2021-09-21T22:55:38.233Z",
+          "user_email": "mattdkragen@gmail.com"
         }
       ]
     }


### PR DESCRIPTION
What was Done:
- Implemented an indicator on new Checklist Items to display the user who added that item to the Checklist
- Arrange methods to pass user_email params through controller, facade, service, poro for Checklist Item
- Changed content in JSON fixtures to reflect back-end DB migration

Road Blocks:
- Current setup will require altering params to NOT auto-assign new checklist items to current_user

Test Coverage:
- [X] I have tested this code with RSpec
- [] Simplecov coverage is >95%

Questions/Notes:
- Will branch off to test a "Volunteer" button for checklist items instead of current_user auto-assignment